### PR TITLE
Response v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Conch now returns version 3 of the certificate sign response.
+  See https://conch.readthedocs.io/stable/api.html for the details.
 - The term "platform" has been replaced by the term "resource".
 - The mapper configuration has changed such that only a single mapper is now allowed.
 - The format required by the v1 `project_infra` mapper has changed.
-- The `short_name` and `projects` claims are now not required in all cases.
+- The `short_name` and `projects` claims are now not required in all cases, depending on the mapper used.
 
 ## [0.3.5] - 2025-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- Conch now returns version 3 of the certificate sign response.
+- The term "platform" has been replaced by the term "resource".
+- The mapper configuration has changed such that only a single mapper is now allowed.
+- The format required by the v1 `project_infra` mapper has changed.
+- The `short_name` and `projects` claims are now not required in all cases.
+
 ## [0.3.5] - 2025-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The mapper configuration has changed such that only a single mapper is now allowed.
 - The format required by the v1 `project_infra` mapper has changed.
 - The `short_name` and `projects` claims are now not required in all cases, depending on the mapper used.
+- The config key `platforms` has been renamed to `resources`.
+- Now supports a different signing key per platform. To enable this,
+  the config key `signing_key_path` has been replaced with
+  `signing_key_dir` which should contain the keys for each resource.
 
 ## [0.3.5] - 2025-09-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,9 @@ dependencies = [
  "http-serde",
  "jsonwebtoken",
  "openidconnect",
+ "pretty_assertions",
  "rand_core",
+ "rstest",
  "serde",
  "serde_json",
  "ssh-key",
@@ -514,6 +516,12 @@ dependencies = [
  "powerfmt",
  "serde",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -678,10 +686,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -690,9 +715,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -737,6 +764,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -1603,12 +1636,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1765,6 +1817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1909,36 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2903,6 +2991,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ url = "2.5"
 [build-dependencies]
 built = { version = "0.7", default-features = false, features = ["git2"] }
 
+[dev-dependencies]
+rstest = "0.24"
+pretty_assertions = "1.4"
+
 [profile.release]
 strip = true
 lto = true

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ then, you can create a `values.yaml` like:
 ---
 config:
   issuer: "https://keycloak.example.com/realms/example"
-  platforms:
+  resources:
     service-one:
       alias: "s1.example"
       hostname: "s1.example.com"
@@ -56,7 +56,7 @@ signing_key_path = "/signing_key"
 
 issuer = "https://keycloak.example.com/realms/example"
 
-[platforms.service-one]
+[resources.service-one]
 alias = "s1.example"
 hostname = "s1.example.com"
 proxy_jump = "jump.example.com"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Conch is an SSH CA for use in AIRR sites.
 
 ## Installation
 
-Conch can be deployed in a few different ways, but all require a private SSH signing key to be created:
+Conch can be deployed in a few different ways, but all require a private SSH signing key to be created.
+Assuming you have a resource you want to enable SSH access to called `service-one`:
 
 ```sh
-ssh-keygen -q -t ed25519 -f ssh_signing_key -C '' -N ''
+ssh-keygen -q -t ed25519 -f service-one -C '' -N ''
 ```
 
 ### Helm
@@ -20,8 +21,8 @@ ssh-keygen -q -t ed25519 -f ssh_signing_key -C '' -N ''
 First, create the SSH signing key and put it in a `Secret`:
 
 ```sh
-kubectl create secret generic conch-signing-key-secret --from-file=key=ssh_signing_key
-rm ssh_signing_key
+kubectl create secret generic conch-signing-key-secret --from-file=service-one=service-one
+rm service-one
 ```
 
 then, you can create a `values.yaml` like:
@@ -52,7 +53,7 @@ Conch can be deployed as a container using e.g. Podman.
 Set up the config file:
 
 ```toml
-signing_key_path = "/signing_key"
+signing_key_path = "/service-one"
 
 issuer = "https://keycloak.example.com/realms/example"
 
@@ -67,7 +68,7 @@ and run the container, pointing it to those two files:
 ```sh
 podman run \
   -v conch.toml:/conch.toml \
-  -v ssh_signing_key:/signing_key \
+  -v service-one:/service-one \
   -e RUST_LOG=info \
   ghcr.io/isambard-sc/conch:0.1.4 --config=/conch.toml
 ```

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,7 +71,49 @@ Conch provides a HTTP API to perform signing requests.
 
    :>json string certificate: the SSH certificate
    :>json Resources resources: the resources the certificate can be used on. See :confval:`resources` for the structure.
-   :>json Associations associations: The associations between the palatforms and the projects. This is controlled by the :confval:`mapper` configuration value.
+   :>json Associations associations:
+      The associations between the resources and their projects or user details.
+
+      Depending on the value of :confval:`mapper`, the contents of this will vary:
+
+      :confval:`single`/:confval:`per_resource`:
+         .. sourcecode:: json
+
+            "associations": {
+              "resources": {
+                "batch.cluster1.example": {
+                  "username": "foo"
+                },
+                "batch.cluster2.example": {
+                  "username": "bar"
+                }
+              }
+            }
+
+      :confval:`project_infra` ``v1``:
+         .. sourcecode:: json
+
+            "associations": {
+              "project-a": {
+                "name": "Project A",
+                "resources": {
+                  "batch.cluster1.example": {
+                    "username": "user.proj-a"
+                  },
+                  "batch.cluster2.example": {
+                    "username": "user.proj-a"
+                  }
+                }
+              },
+              "project-b": {
+                "name": "Project B",
+                "resources": {
+                 "batch.cluster2.example": {
+                   "username": "user.proj-b"
+                  }
+                }
+              }
+            },
    :>json string user: the email address of the user
    :>json integer version: the version of the response. Currently ``3``.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ Conch provides a HTTP API to perform signing requests.
 
       {
         "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>",
-        "platforms": {
+        "resources": {
           "batch.cluster1.example": {
             "alias": "cluster1.example",
             "hostname": "1.access.example.com",
@@ -40,17 +40,29 @@ Conch provides a HTTP API to perform signing requests.
             "proxy_jump": "bastion.example.com"
           }
         },
-        "projects": {
-          "project-a": [
-            "batch.cluster1.example",
-          ],
-          "project-b": [
-            "batch.cluster2.example"
-          ]
+        "associations": {
+          "project-a": {
+            "name": "Project A",
+            "resources": {
+              "batch.cluster1.example": {
+                "username": "user.proj-a"
+              },
+              "batch.cluster2.example": {
+                "username": "user.proj-a"
+              }
+            }
+          },
+          "project-b": {
+            "name": "Project B",
+            "resources": {
+              "batch.cluster2.example": {
+                "username": "user.proj-b"
+              }
+            }
+          }
         },
-        "short_name": "test_person",
         "user": "test@example.com",
-        "version": 2
+        "version": 3
       }
 
    :query string public_key: the SSH public key to sign
@@ -58,11 +70,10 @@ Conch provides a HTTP API to perform signing requests.
    :<header Authorization: an OIDC access token in JWT form. See :ref:`claims` for more information on the contents.
 
    :>json string certificate: the SSH certificate
-   :>json Platforms platforms: the platforms the certificate can be used on. See :confval:`platforms` for the structure.
-   :>json Project projects: the projects the user is part of. This is extracted from the `projects` :ref:`claim <claims>`.
-   :>json string short_name: the short name of the user
+   :>json Resources resources: the resources the certificate can be used on. See :confval:`resources` for the structure.
+   :>json Associations associations: The associations between the palatforms and the projects. This is controlled by the :confval:`mapper` configuration value.
    :>json string user: the email address of the user
-   :>json integer version: the version of the response. Currently ``2``.
+   :>json integer version: the version of the response. Currently ``3``.
 
 .. http:get:: /issuer
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,6 @@ Conch provides a HTTP API to perform signing requests.
       Content-Type: application/json
 
       {
-        "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>",
         "resources": {
           "batch.cluster1.example": {
             "alias": "cluster1.example",
@@ -45,10 +44,12 @@ Conch provides a HTTP API to perform signing requests.
             "name": "Project A",
             "resources": {
               "batch.cluster1.example": {
-                "username": "user.proj-a"
+                "username": "user.proj-a",
+                "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
               },
               "batch.cluster2.example": {
-                "username": "user.proj-a"
+                "username": "user.proj-a",
+                "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
               }
             }
           },
@@ -56,7 +57,8 @@ Conch provides a HTTP API to perform signing requests.
             "name": "Project B",
             "resources": {
               "batch.cluster2.example": {
-                "username": "user.proj-b"
+                "username": "user.proj-b",
+                "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
               }
             }
           }
@@ -69,7 +71,6 @@ Conch provides a HTTP API to perform signing requests.
 
    :<header Authorization: an OIDC access token in JWT form. See :ref:`claims` for more information on the contents.
 
-   :>json string certificate: the SSH certificate
    :>json Resources resources: the resources the certificate can be used on. See :confval:`resources` for the structure.
    :>json Associations associations:
       The associations between the resources and their projects or user details.
@@ -82,10 +83,12 @@ Conch provides a HTTP API to perform signing requests.
             "associations": {
               "resources": {
                 "batch.cluster1.example": {
-                  "username": "foo"
+                  "username": "foo",
+                  "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
                 },
                 "batch.cluster2.example": {
-                  "username": "bar"
+                  "username": "bar",
+                  "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
                 }
               }
             }
@@ -98,10 +101,12 @@ Conch provides a HTTP API to perform signing requests.
                 "name": "Project A",
                 "resources": {
                   "batch.cluster1.example": {
-                    "username": "user.proj-a"
+                    "username": "user.proj-a",
+                    "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
                   },
                   "batch.cluster2.example": {
-                    "username": "user.proj-a"
+                    "username": "user.proj-a",
+                    "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
                   }
                 }
               },
@@ -109,7 +114,8 @@ Conch provides a HTTP API to perform signing requests.
                 "name": "Project B",
                 "resources": {
                  "batch.cluster2.example": {
-                   "username": "user.proj-b"
+                   "username": "user.proj-b",
+                    "certificate": "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC<example snipped>"
                   }
                 }
               }

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -29,10 +29,11 @@ All the examples below show the syntax for both.
    The OIDC client ID that is configured at :confval:`issuer`.
    For example, it could be set to ``"clifton"``.
 
-.. confval:: signing_key_path
+.. confval:: signing_key_dir
    :type: String (path)
 
-   This must be set to the path on disk where the private SSH key is stored.
+   This must be set to the path on disk where the private SSH keys are stored.
+   Each resource must have its own signing key, named identically to the resource ID in :confval:`resources`.
 
 .. confval:: resources
    :type: Table

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,11 +61,10 @@ Glossary
 .. glossary::
 
    Project
-      A project is intended to describe a time-limited collection of users with access to a particular set of :term:`platform`.
+      A project is intended to describe a time-limited collection of users with access to a particular set of :term:`resource`.
 
-   Platform
-      A platform is a collection of resources.
-      In the context of Conch, it is anything which can be accessed via SSH.
+   Resource
+      In the context of Conch, a resource is anything which can be accessed via SSH.
       For example it might be a specific batch cluster or a development environment.
 
    Mapper

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,5 +70,5 @@ Glossary
    Mapper
       A configurable function which takes claims and creates principals in the SSH certificate.
 
-.. _SSH certificate: https://datatracker.ietf.org/doc/draft-miller-ssh-cert/
+.. _SSH certificate: https://datatracker.ietf.org/doc/draft-ietf-sshm-cert/
 .. _SemVer: https://semver.org/spec/v2.0.0.html

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,8 +30,8 @@ then, you can create a ``values.yaml`` (see :doc:`config` for details) like:
    ---
    config:
      issuer: "..."
-     platforms: [...]
-     mappers: [...]
+     resources: [...]
+     mapper: [...]
      extensions: [...]
 
 Note that the Helm chart manages the config value :confval:`signing_key_path` for you by mounting the file as a read-only volume so you do not need to set it.
@@ -85,48 +85,13 @@ Claims required
 When requesting an SSH certificate from Conch, a user must authenticate themselves by passing a JSON Web Token.
 Conch will validate this JWT by checking that is was signed by an :confval:`issuer` that you define.
 
-There are three JWT claims that Conch requires in order to generate the response containing the signed certificate:
+There is one JWT claim that Conch requires in order to generate the response containing the signed certificate:
 
 ``email``
    This must be a string containing some unique identifier for the user.
    Usually this is the email address of the user.
 
-``short_name``
-   This must be a string containing a UNIX username-compatible name.
-
-   If using the ``project_infra`` version 1 mapper, this will be combined with the :term:`project` names to create the principals in the certificate.
-
-``projects``
-   This must be a JSON object containing a string key for each :term:`project` name,
-   with the value being a list of objects containing a ``name`` member giving the project name and a ``resources`` member giving the :term:`platform`\ s  (see :confval:`platforms`) that the project is available on.
-   For example, this could look like:
-
-   .. code-block:: json
-
-      {
-         "project-a": {
-            "name": "Project A",
-            "resources": [
-               {
-                  "name": "batch.cluster1.example",
-                  "username": "user.proj-a"
-               },
-               {
-                  "name": "batch.cluster2.example",
-                  "username": "user.proj-a"
-               }
-            ]
-         },
-         "project-b": {
-            "name": "Project B",
-            "resources": [
-               {   
-                  "name": "batch.cluster2.example",
-                  "username": "user.proj-b"
-               }
-            ]
-         }
-      }
+Other claims may be required, depending on which mapper you configure.
 
 .. _releases: https://github.com/isambard-sc/conch/releases
 .. _Clifton: https://github.com/isambard-sc/clifton/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ Conch can be deployed in a few different way, but all require a private SSH sign
 
 .. code-block:: shell-session
 
-   $ ssh-keygen -q -t ed25519 -f ssh_signing_key -C '' -N ''
+   $ ssh-keygen -q -t ed25519 -f service-one -C '' -N ''
 
 Conch reads the signing key live on each signing request.
 This means that if you replace the private key on disk, any future requests will use it.
@@ -20,8 +20,8 @@ First, create the SSH signing key and put it in a ``Secret``:
 
 .. code-block:: shell-session
 
-   $ kubectl create secret generic conch-signing-key-secret --from-file=key=ssh_signing_key
-   $ rm ssh_signing_key
+   $ kubectl create secret generic conch-signing-key-secret --from-file=service-one=service-one
+   $ rm service-one
 
 then, you can create a ``values.yaml`` (see :doc:`config` for details) like:
 
@@ -34,7 +34,7 @@ then, you can create a ``values.yaml`` (see :doc:`config` for details) like:
      mapper: [...]
      extensions: [...]
 
-Note that the Helm chart manages the config value :confval:`signing_key_path` for you by mounting the file as a read-only volume so you do not need to set it.
+Note that the Helm chart manages the config value :confval:`signing_key_dir` for you by mounting the file as a read-only volume so you do not need to set it.
 
 You can then install the chart with:
 

--- a/helm/conch/templates/configmap.yaml
+++ b/helm/conch/templates/configmap.yaml
@@ -9,5 +9,5 @@ metadata:
     {{- include "conch.labels" . | indent 4 }}
 data:
   conch.toml: |
-    signing_key_path = "{{ .Values.signing_key_dir }}/key"
+    signing_key_dir = "{{ .Values.signing_key_dir }}"
     {{ .Values.config | toToml | nindent 4 }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,7 +636,7 @@ async fn sign(
                 ssh_key::PrivateKey::read_openssh_file(
                     &state.config.signing_key_dir.join(r_id.0.clone()),
                 )
-                .context("Could not load signing key.")?,
+                .context(format!("Could not load signing key for `{}`.", r_id.0))?,
             ))
         })
         .collect::<Result<_>>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ struct ProjectId(String);
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 struct ProjectName(String);
 
-/// A UNIX username as underatood by SSH
+/// A UNIX username as understood by SSH
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
 struct Username(String);
 
@@ -692,7 +692,7 @@ mod tests {
                 },
                 "proj2": {
                     "name": "Project 2",
-                    "resources": [ // USe the old-form resources list
+                    "resources": [ // Use the old-form resources list
                         {
                             "name": "cluster1",
                             "username": "user1.p2",

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,6 +540,13 @@ impl<'a> Signer {
         }
     }
 
+    #[tracing::instrument(
+        skip(self),
+        fields(
+            resource_name = &resource_name.0,
+            principal = &principal.0,
+        )
+    )]
     fn sign(
         &self,
         resource_name: &ResourceName,

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,13 +195,6 @@ async fn shutdown_signal() {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
-struct ProjectId(String);
-
-/// A human-readable name for the project
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
-struct ProjectName(String);
-
 /// A UNIX username as understood by SSH
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
 struct Username(String);
@@ -251,62 +244,84 @@ struct ResourceAssociationClaim {
     username: Username,
 }
 
-#[derive(Clone, Debug, Serialize)]
-struct Project {
-    name: ProjectName,
-    resources: HashMap<ResourceName, ResourceAssociation>,
-}
+/// Types for the ProjectInfra mapper
+mod project_infra {
+    use std::collections::HashMap;
 
-type ProjectsClaim = HashMap<ProjectId, ProjectClaim>;
+    use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize)]
-struct ProjectClaim {
-    name: ProjectName,
-    #[serde(deserialize_with = "deserialize_resource_list")]
-    resources: HashMap<ResourceName, ResourceAssociationClaim>,
-}
+    use crate::{ResourceAssociation, ResourceAssociationClaim, ResourceName, Username};
 
-/// Allow converting from list of entries to the new format.
-/// At some point this will be deprecated.
-/// The old format had the resources claim be a list of objects with
-/// the resource name as an value inside. The new format is a mapping
-/// of resource name to an object.
-fn deserialize_resource_list<'de, D>(
-    deserializer: D,
-) -> Result<HashMap<ResourceName, ResourceAssociationClaim>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    struct OldResourceAssociationClaim {
-        name: ResourceName,
-        username: Username,
+    #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
+    pub(crate) struct ProjectId(pub(crate) String);
+
+    /// A human-readable name for the project
+    #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
+    pub(crate) struct ProjectName(String);
+
+    #[derive(Clone, Debug, Serialize)]
+    pub(crate) struct Project {
+        pub(crate) name: ProjectName,
+        pub(crate) resources: HashMap<ResourceName, ResourceAssociation>,
     }
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum EitherType {
-        Vec(Vec<OldResourceAssociationClaim>),
-        HashMap(HashMap<ResourceName, ResourceAssociationClaim>),
+    pub(crate) type ProjectsClaim = HashMap<ProjectId, ProjectClaim>;
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub(crate) struct ProjectClaim {
+        pub(crate) name: ProjectName,
+        #[serde(deserialize_with = "deserialize_resource_list")]
+        pub(crate) resources: HashMap<ResourceName, ResourceAssociationClaim>,
     }
 
-    Ok(match EitherType::deserialize(deserializer)? {
-        EitherType::Vec(resource_association_claims) => resource_association_claims
-            .iter()
-            .map(|claim| {
-                (
-                    claim.name.clone(),
-                    ResourceAssociationClaim {
-                        username: claim.username.clone(),
-                    },
-                )
-            })
-            .collect(),
-        EitherType::HashMap(hash_map) => hash_map,
-    })
-}
+    /// Allow converting from list of entries to the new format.
+    /// At some point this will be deprecated.
+    /// The old format had the resources claim be a list of objects with
+    /// the resource name as a value inside. The new format is a mapping
+    /// of resource name to an object.
+    fn deserialize_resource_list<'de, D>(
+        deserializer: D,
+    ) -> Result<HashMap<ResourceName, ResourceAssociationClaim>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct OldResourceAssociationClaim {
+            name: ResourceName,
+            username: Username,
+        }
 
-type Projects = HashMap<ProjectId, Project>;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum EitherType {
+            Vec(Vec<OldResourceAssociationClaim>),
+            HashMap(HashMap<ResourceName, ResourceAssociationClaim>),
+        }
+
+        Ok(match EitherType::deserialize(deserializer)? {
+            EitherType::Vec(resource_association_claims) => resource_association_claims
+                .iter()
+                .map(|claim| {
+                    (
+                        claim.name.clone(),
+                        ResourceAssociationClaim {
+                            username: claim.username.clone(),
+                        },
+                    )
+                })
+                .collect(),
+            EitherType::HashMap(hash_map) => hash_map,
+        })
+    }
+
+    pub(crate) type Projects = HashMap<ProjectId, Project>;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub(crate) enum Version {
+        V1,
+    }
+}
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
 struct Claims(serde_json::Value);
@@ -383,7 +398,7 @@ struct SignResponse {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Associations {
-    Projects(Projects),
+    Projects(project_infra::Projects),
     Resources(HashMap<ResourceName, ResourceAssociation>),
 }
 
@@ -416,12 +431,6 @@ impl Associations {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum ProjectInfraVersion {
-    V1,
-}
-
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
 struct ClaimName(String);
 
@@ -434,7 +443,7 @@ impl ClaimName {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Mapper {
-    ProjectInfra(ProjectInfraVersion),
+    ProjectInfra(project_infra::Version),
     Single(ClaimName),
     PerResource(ClaimName),
 }
@@ -448,8 +457,9 @@ impl Mapper {
     ) -> Result<Associations> {
         match self {
             Mapper::ProjectInfra(version) => match version {
-                ProjectInfraVersion::V1 => {
-                    let all_projects: ProjectsClaim = claims.parse(&ClaimName::new("projects"))?;
+                project_infra::Version::V1 => {
+                    let all_projects: project_infra::ProjectsClaim =
+                        claims.parse(&ClaimName::new("projects"))?;
 
                     // Filter the list of resources in each project so that only those
                     // that are referenced in the relevant resources list are kept.
@@ -459,7 +469,7 @@ impl Mapper {
                         .flat_map(|(project_id, project)| -> Result<_> {
                             Ok((
                                 project_id.clone(),
-                                Project {
+                                project_infra::Project {
                                     name: project.name.clone(),
                                     resources: project
                                         .resources
@@ -670,7 +680,7 @@ async fn sign(
                     .iter()
                     .map(|(project_id, project)| {
                         let project_components = project_id.0.split(".").collect::<Vec<&str>>();
-                        let project_id = ProjectId(
+                        let project_id = project_infra::ProjectId(
                             project_components[0..project_components.len() - 1].join("."),
                         );
                         (project_id, project.clone())
@@ -1004,7 +1014,7 @@ mod tests {
         claims_with_project_associations: Claims,
     ) -> Result<()> {
         let signer = make_signer(&resources, claims_with_project_associations.email()?);
-        let principals = Mapper::ProjectInfra(ProjectInfraVersion::V1)
+        let principals = Mapper::ProjectInfra(project_infra::Version::V1)
             .map(&claims_with_project_associations, &resources, &signer)?
             .principals()?;
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,10 +325,6 @@ impl Claims {
     fn email(&self) -> Result<String> {
         self.parse(&ClaimName::new("email"))
     }
-
-    fn projects(&self) -> Result<ProjectsClaim> {
-        self.parse(&ClaimName::new("projects"))
-    }
 }
 
 impl FromRequestParts<Arc<AppState>> for Claims {
@@ -453,7 +449,7 @@ impl Mapper {
         match self {
             Mapper::ProjectInfra(version) => match version {
                 ProjectInfraVersion::V1 => {
-                    let all_projects = claims.projects()?;
+                    let all_projects: ProjectsClaim = claims.parse(&ClaimName::new("projects"))?;
 
                     // Filter the list of resources in each project so that only those
                     // that are referenced in the relevant resources list are kept.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,17 +56,18 @@ struct ResourceAlias(String);
 
 /// The configuration of Conch
 mod config {
-    use std::collections::HashMap;
+    use serde::Deserialize;
 
-    use serde::{Deserialize, Serialize};
-
-    use crate::{Mapper, ResourceAlias, ResourceName};
+    use crate::{Extension, Mapper, Resources};
 
     #[derive(Debug, Deserialize)]
     pub(crate) struct Config {
+        /// The URL of the OAuth authorisation server
         pub(crate) issuer: url::Url,
+        /// THe directory that contains the SSH signing keys
         pub(crate) signing_key_dir: std::path::PathBuf,
         pub(crate) client_id: openidconnect::ClientId,
+        /// The resources to provide certificates for
         #[serde(default)]
         pub(crate) resources: Resources,
         #[serde(default)]
@@ -84,29 +85,6 @@ mod config {
         #[default]
         Full,
         Json,
-    }
-
-    /// SSH certificate extension
-    #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
-    pub(crate) struct Extension(String);
-
-    impl From<Extension> for String {
-        fn from(val: Extension) -> Self {
-            val.0
-        }
-    }
-
-    pub(crate) type Resources = HashMap<ResourceName, Resource>;
-
-    #[derive(Clone, Debug, Deserialize, Serialize)]
-    pub(crate) struct Resource {
-        /// The short name that will be used in e.g. a SSH host alias
-        pub(crate) alias: ResourceAlias,
-        /// The actual hostname of the resource's SSH server.
-        #[serde(with = "http_serde::authority")]
-        pub(crate) hostname: axum::http::uri::Authority,
-        /// The hostname of the SSH jump host.
-        pub(crate) proxy_jump: Option<String>,
     }
 }
 
@@ -195,6 +173,16 @@ async fn shutdown_signal() {
     }
 }
 
+/// SSH certificate extension
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
+pub(crate) struct Extension(String);
+
+impl From<Extension> for String {
+    fn from(val: Extension) -> Self {
+        val.0
+    }
+}
+
 /// A UNIX username as understood by SSH
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
 struct Username(String);
@@ -215,16 +203,6 @@ struct Resource {
     hostname: axum::http::uri::Authority,
     /// The hostname of the SSH jump host.
     proxy_jump: Option<String>,
-}
-
-impl From<crate::config::Resource> for Resource {
-    fn from(resource: crate::config::Resource) -> Self {
-        Self {
-            alias: resource.alias,
-            hostname: resource.hostname,
-            proxy_jump: resource.proxy_jump,
-        }
-    }
 }
 
 impl From<Username> for Principal {
@@ -395,6 +373,9 @@ struct SignResponse {
     version: u32,
 }
 
+/// The information in the response which tells the caller what
+/// resources can be accessed, with what identities, and the
+/// relevant certificates.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Associations {
@@ -449,12 +430,7 @@ enum Mapper {
 }
 
 impl Mapper {
-    fn map(
-        &self,
-        claims: &Claims,
-        resources: &crate::config::Resources,
-        signer: &Signer,
-    ) -> Result<Associations> {
+    fn map(&self, claims: &Claims, resources: &Resources, signer: &Signer) -> Result<Associations> {
         match self {
             Mapper::ProjectInfra(version) => match version {
                 project_infra::Version::V1 => {
@@ -536,7 +512,7 @@ struct Signer {
     signing_keys: HashMap<ResourceName, ssh_key::PrivateKey>,
     public_key: ssh_key::PublicKey,
     key_id: String,
-    extensions: Vec<crate::config::Extension>,
+    extensions: Vec<Extension>,
 }
 
 impl<'a> Signer {
@@ -544,7 +520,7 @@ impl<'a> Signer {
         signing_keys: HashMap<ResourceName, ssh_key::PrivateKey>,
         public_key: ssh_key::PublicKey,
         key_id: String,
-        extensions: Vec<crate::config::Extension>,
+        extensions: Vec<Extension>,
     ) -> Self {
         Self {
             signing_keys,
@@ -698,10 +674,7 @@ async fn sign(
 
     let response = SignResponse {
         associations,
-        resources: resources
-            .into_iter()
-            .map(|(r_id, r)| (r_id, r.into()))
-            .collect(),
+        resources: resources,
         user: claims.email()?,
         version: 3,
     };
@@ -812,7 +785,7 @@ mod tests {
         serde_json::from_value(jwt_payload).expect("Could not parse claims.")
     }
 
-    fn make_signer(resources: &crate::config::Resources, email: String) -> Signer {
+    fn make_signer(resources: &Resources, email: String) -> Signer {
         let public_key = ssh_key::PrivateKey::random(
             &mut ssh_key::rand_core::OsRng,
             ssh_key::Algorithm::Ed25519,
@@ -862,7 +835,7 @@ mod tests {
             "projects": {
                 "proj1": {
                     "name": "Project 1",
-                    "resources": {
+                    "resources": { // Use the new-form resources map
                         "cluster1": {
                             "username": "user1.p1",
                         },
@@ -897,11 +870,11 @@ mod tests {
     }
 
     #[rstest::fixture]
-    fn resources() -> crate::config::Resources {
+    fn resources() -> Resources {
         [
             (
                 ResourceName("cluster1".to_string()),
-                crate::config::Resource {
+                Resource {
                     alias: ResourceAlias("1.site".to_string()),
                     hostname: axum::http::uri::Authority::from_static("c1.example.com"),
                     proxy_jump: None,
@@ -909,7 +882,7 @@ mod tests {
             ),
             (
                 ResourceName("cluster2".to_string()),
-                crate::config::Resource {
+                Resource {
                     alias: ResourceAlias("2.site".to_string()),
                     hostname: axum::http::uri::Authority::from_static("c2.example.com"),
                     proxy_jump: None,
@@ -917,7 +890,7 @@ mod tests {
             ),
             (
                 ResourceName("private_cluster".to_string()),
-                crate::config::Resource {
+                Resource {
                     alias: ResourceAlias("priv.site".to_string()),
                     hostname: axum::http::uri::Authority::from_static("priv.example.com"),
                     proxy_jump: None,
@@ -928,11 +901,11 @@ mod tests {
     }
 
     #[rstest::fixture]
-    fn unmatching_resources() -> crate::config::Resources {
+    fn unmatching_resources() -> Resources {
         [
             (
                 ResourceName("othercluster1".to_string()),
-                crate::config::Resource {
+                Resource {
                     alias: ResourceAlias("1.othersite".to_string()),
                     hostname: axum::http::uri::Authority::from_static("c1.example.org"),
                     proxy_jump: None,
@@ -940,7 +913,7 @@ mod tests {
             ),
             (
                 ResourceName("othercluster2".to_string()),
-                crate::config::Resource {
+                Resource {
                     alias: ResourceAlias("2.othersite".to_string()),
                     hostname: axum::http::uri::Authority::from_static("c2.example.org"),
                     proxy_jump: None,
@@ -951,7 +924,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    fn single(resources: crate::config::Resources, simple_claims: Claims) -> Result<()> {
+    fn single(resources: Resources, simple_claims: Claims) -> Result<()> {
         let signer = make_signer(&resources, simple_claims.email()?);
         let principals = Mapper::Single(ClaimName("email".to_string()))
             .map(&simple_claims, &resources, &signer)?
@@ -966,7 +939,7 @@ mod tests {
 
     #[rstest::rstest]
     fn resource_usernames(
-        resources: crate::config::Resources,
+        resources: Resources,
         claims_with_resource_associations: Claims,
     ) -> Result<()> {
         let signer = make_signer(&resources, claims_with_resource_associations.email()?);
@@ -987,7 +960,7 @@ mod tests {
 
     #[rstest::rstest]
     fn resource_usernames_unmatching(
-        unmatching_resources: crate::config::Resources,
+        unmatching_resources: Resources,
         claims_with_resource_associations: Claims,
     ) -> Result<()> {
         let signer = make_signer(
@@ -1010,7 +983,7 @@ mod tests {
 
     #[rstest::rstest]
     fn project_usernames(
-        resources: crate::config::Resources,
+        resources: Resources,
         claims_with_project_associations: Claims,
     ) -> Result<()> {
         let signer = make_signer(&resources, claims_with_project_associations.email()?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ struct ResourceName(String);
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ResourceAlias(String);
 
+/// The configuration of Conch
 mod config {
     use std::collections::HashMap;
 
@@ -85,6 +86,7 @@ mod config {
         Json,
     }
 
+    /// SSH certificate extension
     #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
     pub(crate) struct Extension(String);
 
@@ -170,6 +172,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Catch termination signals to shutdown Tokio properly
 async fn shutdown_signal() {
     let ctrl_c = async {
         #[allow(clippy::expect_used)]
@@ -195,6 +198,7 @@ async fn shutdown_signal() {
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 struct ProjectId(String);
 
+/// A human-readable name for the project
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 struct ProjectName(String);
 
@@ -208,6 +212,7 @@ struct Principal(String);
 
 type Resources = HashMap<ResourceName, Resource>;
 
+/// A remotely-accessible resource over SSH
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Resource {
     /// The short name that will be used in e.g. a SSH host alias
@@ -263,6 +268,9 @@ struct ProjectClaim {
 
 /// Allow converting from list of entries to the new format.
 /// At some point this will be deprecated.
+/// The old format had the resources claim be a list of objects with
+/// the resource name as an value inside. The new format is a mapping
+/// of resource name to an object.
 fn deserialize_resource_list<'de, D>(
     deserializer: D,
 ) -> Result<HashMap<ResourceName, ResourceAssociationClaim>, D::Error>

--- a/tests/integration/basic.hurl
+++ b/tests/integration/basic.hurl
@@ -20,7 +20,7 @@ jsonpath "$.version" == 1
 GET {{conch}}/public_key
 HTTP 200
 [Asserts]
-body startsWith "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5"
+jsonpath "$.keys['slurm.3.example']" startsWith "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5"
 
 POST {{issuer}}/protocol/openid-connect/token
 [FormParams]
@@ -57,10 +57,13 @@ Authorization: Bearer {{ test1_token }}
 public_key: {{ ssh_key_ed25519_pub }}
 HTTP 200
 [Asserts]
-jsonpath "$.certificate" exists
+# jsonpath "$.certificate" exists
 jsonpath "$.associations.projects['proj1'].resources['slurm.ai.example'].username" == "test1"
+jsonpath "$.associations.projects['proj1'].resources['slurm.ai.example'].certificate" exists
 jsonpath "$.associations.projects['proj1'].resources['slurm.3.example'].username" == "test1"
+jsonpath "$.associations.projects['proj1'].resources['slurm.3.example'].certificate" exists
 jsonpath "$.associations.projects['proj2'].resources['slurm.ai.example'].username" == "test2"
+jsonpath "$.associations.projects['proj2'].resources['slurm.ai.example'].certificate" exists
 jsonpath "$.associations.projects['proj2'].resources['slurm.3.example']" not exists
 jsonpath "$.associations.projects['proj2'].resources['slurm.missing.example']" not exists
 jsonpath "$.resources['slurm.ai.example'].alias" == "ai.example"
@@ -74,7 +77,7 @@ Authorization: Bearer {{ test1_token }}
 public_key: {{ ssh_key_rsa_3072_pub }}
 HTTP 200
 [Asserts]
-jsonpath "$.certificate" exists
+jsonpath "$.user" exists
 
 GET {{conch}}/sign
 Authorization: Bearer {{ test1_token }}

--- a/tests/integration/basic.hurl
+++ b/tests/integration/basic.hurl
@@ -58,15 +58,15 @@ public_key: {{ ssh_key_ed25519_pub }}
 HTTP 200
 [Asserts]
 jsonpath "$.certificate" exists
-jsonpath "$.projects['proj1']" includes "slurm.ai.example"
-jsonpath "$.projects['proj1']" includes "slurm.3.example"
-jsonpath "$.projects['proj2']" includes "slurm.ai.example"
-jsonpath "$.projects['proj2']" not includes "slurm.3.example"
-jsonpath "$.projects['proj2']" not includes "slurm.missing.example"
-jsonpath "$.platforms['slurm.ai.example']['alias']" == "ai.example"
-jsonpath "$.platforms['slurm.3.example']['alias']" == "3.example"
+jsonpath "$.associations.projects['proj1'].resources['slurm.ai.example'].username" == "test1"
+jsonpath "$.associations.projects['proj1'].resources['slurm.3.example'].username" == "test1"
+jsonpath "$.associations.projects['proj2'].resources['slurm.ai.example'].username" == "test2"
+jsonpath "$.associations.projects['proj2'].resources['slurm.3.example']" not exists
+jsonpath "$.associations.projects['proj2'].resources['slurm.missing.example']" not exists
+jsonpath "$.resources['slurm.ai.example'].alias" == "ai.example"
+jsonpath "$.resources['slurm.3.example'].alias" == "3.example"
 jsonpath "$.user" == "test@example.com"
-jsonpath "$.version" == 2
+jsonpath "$.version" == 3
 
 GET {{conch}}/sign
 Authorization: Bearer {{ test1_token }}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -24,6 +24,7 @@ metadata:
 data:
   slurm.ai.example: $(base64 --wrap=0 temp/signing_key)
   slurm.3.example: $(base64 --wrap=0 temp/signing_key)
+  slurm.5.example: $(base64 --wrap=0 temp/signing_key)
 EOF
 header "Getting built conch version"
 version=$(podman run conch:latest --version | tail -n1 | cut -d' ' -f 2)

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -143,15 +143,15 @@ projects1=$(jq tojson << EOF
     "resources": [
       {
         "name": "slurm.ai.example",
-        "username": "test"
+        "username": "test1"
       },
       {
         "name": "slurm.3.example",
-        "username": "test"
+        "username": "test1"
       },
       {
         "name": "slurm.5.example",
-        "username": "test"
+        "username": "test1"
       }
     ]
   },
@@ -160,11 +160,11 @@ projects1=$(jq tojson << EOF
     "resources": [
       {
         "name": "slurm.ai.example",
-        "username": "test"
+        "username": "test2"
       },
       {
         "name": "missing.example",
-        "username": "test"
+        "username": "test2"
       }
     ]
   }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -22,7 +22,8 @@ kind: Secret
 metadata:
   name: conch-signing-key-secret
 data:
-  key: $(base64 --wrap=0 temp/signing_key)
+  slurm.ai.example: $(base64 --wrap=0 temp/signing_key)
+  slurm.3.example: $(base64 --wrap=0 temp/signing_key)
 EOF
 header "Getting built conch version"
 version=$(podman run conch:latest --version | tail -n1 | cut -d' ' -f 2)

--- a/tests/integration/values.yaml
+++ b/tests/integration/values.yaml
@@ -4,7 +4,7 @@
 config:
   issuer: "http://localhost:8080/realms/conch"
   client_id: "conch"
-  platforms:
+  resources:
     slurm.ai.example:
       alias: "ai.example"
       hostname: "ai.access.example.com"
@@ -16,8 +16,8 @@ config:
     slurm.5.example:
       alias: "5.example"
       hostname: "5.access.example.com"
-  mappers:
-    - project_infra: "v1"
+  mapper:
+    project_infra: "v1"
   extensions:
     - "permit-agent-forwarding"
     - "permit-port-forwarding"


### PR DESCRIPTION
This updates the certificate signing response from Conch to a new format which has the following changes:

- The `projects` value has been replaced with `associations` which provides the authentication details relevant to the configuration. The format of this is dependent on the "mapper" chosen.
- Does not include the `short_name` at the top level. This is now not guaranteed to be the same for all resources and so the specific username per resource is contained in `associations`.
- Does not include the `certificate` at the top level. There is now a certificate signed for each project/resource combination, inside `associations`.
- `platforms` is now called `resources`.
- `version` is now `3`.

To support this, the config file also has the following changes:
- The config key `platforms` has been renamed to `resources`.
- To enable different signing keys per platform, the config key `signing_key_path` has been replaced with `signing_key_dir` which should contain the key files for each resource.

This format has been supported in Clifton since 0.3.0.

This is a non-backwards-compatible change (due to changes being required to the configuration) and so will require the next release to be a new major release (though since we're still in pre-1.0.0, it will be a minor release).